### PR TITLE
缩短超时时间,增加协程sleep切换协程

### DIFF
--- a/src/RabbitMqQueueDriver.php
+++ b/src/RabbitMqQueueDriver.php
@@ -134,10 +134,11 @@ class RabbitMqQueueDriver{
         });
         while(count($channel->callbacks)) {
             try{
-                $channel->wait(null,false,10);
+                $channel->wait(null,false,5);
             }catch (\Exception $e){
 
             }
+            \co::sleep(0.001)
         }
         return $job;
     }


### PR DESCRIPTION
避免无法进行其他工作,修复easyswoole 自定义进程无法切换协程进行自定义进程定时器运行: https://github.com/easy-swoole/easyswoole/issues/485